### PR TITLE
Closes #5. Closes #7. Closes #8. Closes #11.

### DIFF
--- a/app/controllers/reminder-list/edit.js
+++ b/app/controllers/reminder-list/edit.js
@@ -2,15 +2,18 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
     actions: {
+
       updateReminder(id) {
         this.get('store').findRecord('reminder', id).then((reminder) => {
           reminder.save().then((reminder) => { this.transitionToRoute('reminder-list.reminder-detail', reminder.id); });
         });
       },
+
       revertReminder(id) {
         this.get('store').findRecord('reminder', id).then((reminder) => {
           reminder.rollbackAttributes();
         });
       }
+
     }
 });

--- a/app/controllers/reminder-list/edit.js
+++ b/app/controllers/reminder-list/edit.js
@@ -14,6 +14,5 @@ export default Ember.Controller.extend({
           reminder.rollbackAttributes();
         });
       }
-
     }
 });

--- a/app/controllers/reminder-list/edit.js
+++ b/app/controllers/reminder-list/edit.js
@@ -4,8 +4,13 @@ export default Ember.Controller.extend({
     actions: {
       updateReminder(id) {
         this.get('store').findRecord('reminder', id).then((reminder) => {
-          reminder.save();
+          reminder.save().then((reminder) => { this.transitionToRoute('reminder-list.reminder-detail', reminder.id); });
         });
+      },
+      revertReminder(id) {
+        this.get('store').findRecord('reminder', id).then((reminder) => {
+          reminder.rollbackAttributes();
+        });
+      }
     }
-  }
 });

--- a/app/routes/reminder-list/new.js
+++ b/app/routes/reminder-list/new.js
@@ -1,4 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Route.extend({
-});

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -15,7 +15,6 @@ p {
 h2 {
   margin-top:0px;
   border-bottom: 1px solid $dark-accent-color;
-
 }
 
 .application {
@@ -34,7 +33,6 @@ h2 {
 
 .reminder-list {
   height: 80vh;
-
   padding: 0px 10px;
   overflow-y: scroll;
   list-style: none;
@@ -74,8 +72,7 @@ button {
   font-size: 25px;
 }
 
-
-form{
+form {
   background-color: $light-accent-color;
   color: $dark-accent-color;
   padding: 20px;
@@ -85,7 +82,7 @@ form{
   margin: auto;
 }
 
-input{
+input {
   border: none;
   margin: 10px 0px;
   background-color: $primary-text-color;
@@ -137,29 +134,29 @@ button:hover {
   border-radius: 5px;
 }
 
-.reminder-list-item:hover{
+.reminder-list-item:hover {
   cursor: pointer;
   background-color: $primary-hover-1;
 }
 
-.reminder-detail-date{
+.reminder-detail-date {
   font-family: $sans;
   margin: 0px;
   color: $dark-accent-color;
 }
 
-.spec-reminder-item{
+.spec-reminder-item {
   border: none;
   margin: 0px;
 }
 
-.reminder-item-date{
+.reminder-item-date {
   font-family: $sans;
   margin: 0px
 }
 
 .reminder-list-item.active {
-  border:none;
+  border: none;
   background-color: rgba($primary-text-color, .8);
   color: $primary-color-1;
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -74,6 +74,11 @@ button {
   font-size: 25px;
 }
 
+.reminder-revert-button {
+  padding-top: 5px;
+  font-size: 25px;
+}
+
 
 form{
   background-color: $light-accent-color;

--- a/app/templates/reminder-list/edit.hbs
+++ b/app/templates/reminder-list/edit.hbs
@@ -4,8 +4,7 @@
     {{ input value=reminder.title class="reminder-title-input" placeholder="Insert Title" }} <br>
     {{ input value=reminder.date type="datetime-local" class="reminder-date-input" placeholder="Insert Date" }} <br>
     {{ textarea value=reminder.notes class="reminder-notes-input" placeholder="Insert Note" }} <br>
-    {{#link-to "reminder-list.reminder-detail" reminder}}
     <button class="reminder-submit-button" {{action "updateReminder" reminder.id on="click"}}>Submit</button>
-    {{/link-to}}
+    <button class="reminder-revert-button" {{action "revertReminder" reminder.id on="click"}}>Revert ↺</button>
 </form>
 {{/with}}

--- a/app/templates/reminder-list/reminder-detail.hbs
+++ b/app/templates/reminder-list/reminder-detail.hbs
@@ -5,6 +5,6 @@
   {{/link-to}}
   <h2 class="spec-reminder-title">{{reminder.title}}</h2>
   <p class="reminder-detail-date">{{reminder.date}}</p>
-  <p>{{reminder.notes}}</p>
+  <p class="reminder-detail-notes">{{reminder.notes}}</p>
   {{/with}}
 </article>

--- a/app/templates/reminder-list/reminder-detail.hbs
+++ b/app/templates/reminder-list/reminder-detail.hbs
@@ -1,7 +1,7 @@
 <article class="reminder-item-detail">
   {{#with model as |reminder| }}
   {{#link-to "reminder-list.edit" reminder}}
-  <span title='edit this reminder'><button class="edit-button">📝</button></span>
+  <span title="edit this reminder"><button class="edit-button">📝</button></span>
   {{/link-to}}
   <h2 class="spec-reminder-title">{{reminder.title}}</h2>
   <p class="reminder-detail-date">{{reminder.date}}</p>

--- a/app/transforms/date.js
+++ b/app/transforms/date.js
@@ -2,13 +2,19 @@ import DS from 'ember-data';
 import moment from 'moment';
 
 export default DS.Transform.extend({
+
   deserialize(serialized) {
-    if (serialized){return moment(serialized).format("dddd, MMM Do, h:mm a");}
+    if (serialized){
+      return moment(serialized).format("dddd, MMM Do, h:mm a");
+    }
     return serialized;
   },
 
   serialize(deserialized){
-    if(deserialized){return moment(deserialized).toISOString();}
+    if(deserialized){
+      return moment(deserialized).toISOString();
+    }  
     return deserialized;
   }
+
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -45,3 +45,16 @@ test('clicking on the ➕ button displays the form', function(assert) {
     assert.equal(Ember.$('.create-reminder-form').length, 1);
   });
 });
+
+test('clicking on the edit button takes you to the :id/edit url', function(assert) {
+
+  visit('/');
+  click('.reminder-list-item:last');
+  click('.edit-button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/5/edit');
+    assert.equal(Ember.$('.create-reminder-form').length, 1);
+    assert.equal(Ember.$('.reminder-revert-button').length, 1);
+  });
+});

--- a/tests/acceptance/reminder-list/edit-test.js
+++ b/tests/acceptance/reminder-list/edit-test.js
@@ -1,0 +1,31 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'remember/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | reminder list/edit', {
+  beforeEach(){
+    server.createList('reminder', 5);
+  },
+  afterEach(){
+    server.shutdown();
+  }
+});
+
+test('visiting the "edit" route', function(assert) {
+  visit('5/edit');
+
+  andThen(function() {
+    assert.equal(currentURL(), '5/edit');
+  });
+});
+
+test('editing a reminder', function(assert) {
+
+  visit('5/edit');
+  fillIn('.reminder-title-input', 'Some title');
+  fillIn('.reminder-notes-input', 'Some notes');
+  click('.reminder-submit-button');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-item:last').text(), 'Some title');
+  });
+});

--- a/tests/acceptance/reminder-list/edit-test.js
+++ b/tests/acceptance/reminder-list/edit-test.js
@@ -26,6 +26,33 @@ test('editing a reminder', function(assert) {
   click('.reminder-submit-button');
 
   andThen(function() {
-    assert.equal(Ember.$('.spec-reminder-item:last').text(), 'Some title');
+    assert.equal(Ember.$('.spec-reminder-title').text(), 'Some title');
+    assert.equal(Ember.$('.reminder-detail-notes').text(), 'Some notes');
+  });
+});
+
+test('revert a reminder', function(assert) {
+
+  visit('5/edit');
+  fillIn('.reminder-title-input', 'Hey');
+  fillIn('.reminder-notes-input', 'How are you?');
+  click('.reminder-submit-button');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-title').text(), 'Hey');
+    assert.equal(Ember.$('.reminder-detail-notes').text(), 'How are you?');
+  });
+
+  andThen(function() {
+    click('.edit-button');
+    fillIn('.reminder-title-input', 'Some title');
+    fillIn('.reminder-notes-input', 'Some notes');
+    click('.reminder-revert-button');
+    visit('5');
+  });
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-title').text(), 'Hey');
+    assert.equal(Ember.$('.reminder-detail-notes').text(), 'How are you?');
   });
 });


### PR DESCRIPTION
## Purpose

Add functionality to revert an 'dirty' edited reminder to its previous state.
## Approach

We used the 'rollbackAttributes()' function, which basically does the trick. This function lives in the 'edit' controller with our 'updateReminder' function. 
### Learning

We figured there must be a way to clear away something's 'dirty' attributes, knowing that Ember keeps track of that stuff, so we went to the docs.
### Test coverage

_Briefly describe what tests you have written and why._
### Merge Dependencies and Related Work

_Link to merge dependency issues or PRs._
### Follow-up tasks
- [Issue #2 (Example)](https://github.com/flexyford/pull-request/issues)
### Screenshots
#### Before
#### After
